### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/public/fixPaths.js
+++ b/public/fixPaths.js
@@ -15,7 +15,8 @@ document.addEventListener('DOMContentLoaded', function() {
   }
   
   // Solo corregimos rutas cuando realmente estamos en GitHub Pages.
-  const isGitHubPages = window.location.hostname.endsWith('github.io');
+  // Stricter check: Host must be exactly of the form "<username>.github.io"
+  const isGitHubPages = /^[a-zA-Z0-9-]+\.github\.io$/.test(window.location.hostname);
 
   if (isGitHubPages) {
     try {


### PR DESCRIPTION
Potential fix for [https://github.com/javier25arroyo/Portafolio/security/code-scanning/1](https://github.com/javier25arroyo/Portafolio/security/code-scanning/1)

To fix the problem, replace the substring/suffix check with a more robust verification that the current hostname matches the expected pattern for GitHub Pages domains. For GitHub Pages, hostnames follow the format `{username}.github.io`. Thus, the script should ensure the hostname has exactly two labels and ends with `.github.io` (or matches a known whitelist if relevant).  

The code in line 18 should be updated to parse the hostname and ensure:
- It ends with `.github.io`.
- It has only two segments (e.g. `username.github.io`), not any subdomains.
  
This can be achieved by:
- Splitting the hostname by `.` and ensuring the last two segments are `github` and `io`, and the array has exactly three elements.  
- Alternatively, using a strict RegExp: `/^[a-zA-Z0-9-]+\.github\.io$/` on the hostname.

Change the assignment to `isGitHubPages` accordingly, _without_ using `endsWith` alone.  
No additional dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
